### PR TITLE
32 feat review 도메인 구현

### DIFF
--- a/http/review.http
+++ b/http/review.http
@@ -1,0 +1,64 @@
+@baseUrl = http://localhost:8080/reviews
+
+@reviewId = 1
+@menuId = 2
+@rating = 4.5
+@content = "Great food!"
+
+@invalidRating = 4.7
+
+@updatedRating = 5.0
+@updatedContent = "Excellent food!"
+
+### 리뷰 생성
+POST {{baseUrl}}
+Content-Type: application/json
+
+{
+  "menuId": {{menuId}},
+  "rating": {{rating}},
+  "content": {{content}}
+}
+
+### 리뷰 생성 실패
+POST {{baseUrl}}
+Content-Type: application/json
+
+{
+  "menuId": {{menuId}},
+  "rating": {{invalidRating}},
+  "content": {{content}}
+}
+
+
+### 리뷰 단건 조회
+GET {{baseUrl}}/{{reviewId}}
+
+
+### 리뷰 전체 조회
+GET {{baseUrl}}
+
+
+### 리뷰 수정
+PUT {{baseUrl}}/{{reviewId}}
+Content-Type: application/json
+
+{
+  "rating": {{updatedRating}},
+  "content": {{updatedContent}}
+}
+
+
+### 리뷰 수정 실패
+PUT {{baseUrl}}/{{reviewId}}
+Content-Type: application/json
+
+{
+  "rating": {{invalidRating}},
+  "content": {{updatedContent}}
+}
+
+
+### 리뷰 삭제
+DELETE {{baseUrl}}/{{reviewId}}
+Content-Type: application/json

--- a/src/main/java/com/sparta/goodbite/domain/review/dto/CreateReviewRequestDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/dto/CreateReviewRequestDto.java
@@ -1,7 +1,7 @@
 package com.sparta.goodbite.domain.review.dto;
 
 import com.sparta.goodbite.domain.menu.entity.Menu;
-import com.sparta.goodbite.domain.review.dto.validation.RatingConstraint;
+import com.sparta.goodbite.domain.review.dto.validation.constraint.RatingConstraint;
 import com.sparta.goodbite.domain.review.entity.Review;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;

--- a/src/main/java/com/sparta/goodbite/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/dto/ReviewResponseDto.java
@@ -1,14 +1,13 @@
 package com.sparta.goodbite.domain.review.dto;
 
-import com.sparta.goodbite.domain.menu.entity.Menu;
 import com.sparta.goodbite.domain.review.entity.Review;
 
-public record ReviewResponseDto(float rating, String content, Menu menu) {
+public record ReviewResponseDto(Long menuId, float rating, String content) {
 
     public static ReviewResponseDto from(Review review) {
         return new ReviewResponseDto(
+            review.getMenu().getId(),
             review.getRating(),
-            review.getContent(),
-            review.getMenu());
+            review.getContent());
     }
 }

--- a/src/main/java/com/sparta/goodbite/domain/review/dto/UpdateReviewRequestDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/dto/UpdateReviewRequestDto.java
@@ -1,6 +1,6 @@
 package com.sparta.goodbite.domain.review.dto;
 
-import com.sparta.goodbite.domain.review.dto.validation.RatingConstraint;
+import com.sparta.goodbite.domain.review.dto.validation.constraint.RatingConstraint;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/sparta/goodbite/domain/review/dto/validation/constraint/RatingConstraint.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/dto/validation/constraint/RatingConstraint.java
@@ -1,5 +1,6 @@
-package com.sparta.goodbite.domain.review.dto.validation;
+package com.sparta.goodbite.domain.review.dto.validation.constraint;
 
+import com.sparta.goodbite.domain.review.dto.validation.validator.RatingValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;

--- a/src/main/java/com/sparta/goodbite/domain/review/dto/validation/validator/RatingValidator.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/dto/validation/validator/RatingValidator.java
@@ -1,5 +1,6 @@
-package com.sparta.goodbite.domain.review.dto.validation;
+package com.sparta.goodbite.domain.review.dto.validation.validator;
 
+import com.sparta.goodbite.domain.review.dto.validation.constraint.RatingConstraint;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 

--- a/src/main/java/com/sparta/goodbite/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/goodbite/exception/GlobalExceptionHandler.java
@@ -19,12 +19,12 @@ public class GlobalExceptionHandler {
         log.error("에러 발생: ", e);
         return ResponseUtil.of(e.getMenuErrorCode().getHttpStatus(), e.getMessage());
     }
-
-
+    
     @ExceptionHandler(ReviewException.class)
     public ResponseEntity<MessageResponseDto> handleReviewException(ReviewException e) {
         log.error("에러 발생: ", e);
         return ResponseUtil.of(e.getReviewErrorCode().getHttpStatus(), e.getMessage());
+    }
 
     @ExceptionHandler(RestaurantException.class)
     public ResponseEntity<MessageResponseDto> handleRestaurantException(RestaurantException e) {


### PR DESCRIPTION
제목 : [🩹FIX] 리뷰 조회 시 프록시 객체 직렬화 문제 발생 수정
bug(issue 번호): #53

## 🔎 작업 내용
- `ReviewResponseDto`가 필드로 `Menu` 엔티티를 직접 가지고 있어서 발생한 문제였고, 엔티티 대신 `menuId`를 가지도록 수정
- 추가로 merge 과정 중 `GlobalExceptionHandler`의 메서드 닫는 중괄호 없는 문제 발견 후 수정
- API 테스트 코드 작성

## 🔗 이슈 링크 #53 

- [x] #53 

resolved: #53
