### PR TITLE
71 refactor 리뷰 도메인 인증인가 적용

### DIFF
--- a/src/main/java/com/sparta/goodbite/auth/security/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/goodbite/auth/security/WebSecurityConfig.java
@@ -7,6 +7,7 @@ import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -122,6 +123,7 @@ public class WebSecurityConfig {
                     .requestMatchers("/admins/**").hasRole(UserRole.ADMIN.name())
                     .requestMatchers("/owners/**").hasRole(UserRole.OWNER.name())
                     .requestMatchers("/customers/").hasRole(UserRole.CUSTOMER.name())
+                    .requestMatchers(HttpMethod.GET, "/reviews/**").permitAll() // 리뷰 조회는 모두 가능
                     .anyRequest().authenticated())
 
             // 기본 폼 로그인을 비활성화, 중복 인증 방지

--- a/src/main/java/com/sparta/goodbite/auth/security/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/goodbite/auth/security/WebSecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -21,6 +22,7 @@ import org.springframework.security.web.authentication.logout.LogoutSuccessHandl
 
 @Configuration
 @RequiredArgsConstructor
+@EnableMethodSecurity // @PreAuthorize 애너테이션 활성화
 @EnableWebSecurity // Spring Security 사용
 public class WebSecurityConfig {
 

--- a/src/main/java/com/sparta/goodbite/common/UserCredentials.java
+++ b/src/main/java/com/sparta/goodbite/common/UserCredentials.java
@@ -2,6 +2,8 @@ package com.sparta.goodbite.common;
 
 public interface UserCredentials {
 
+    Long getId();
+
     String getEmail();
 
     String getPassword();

--- a/src/main/java/com/sparta/goodbite/domain/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/sparta/goodbite/domain/customer/repository/CustomerRepository.java
@@ -1,6 +1,8 @@
 package com.sparta.goodbite.domain.customer.repository;
 
 import com.sparta.goodbite.domain.customer.entity.Customer;
+import com.sparta.goodbite.exception.customer.CustomerErrorCode;
+import com.sparta.goodbite.exception.customer.detail.CustomerNotFoundException;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,4 +14,9 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
     Optional<Customer> findByEmail(String email);
 
     Optional<Customer> findByPhoneNumber(String phoneNumber);
+
+    default Customer findByEmailOrThrow(String email) {
+        return findByEmail(email).orElseThrow(
+            () -> new CustomerNotFoundException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/sparta/goodbite/domain/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/sparta/goodbite/domain/customer/repository/CustomerRepository.java
@@ -8,15 +8,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
 
-    //Optional<Customer> findById(Long customerId);
     Optional<Customer> findByNickname(String nickname);
 
     Optional<Customer> findByEmail(String email);
 
     Optional<Customer> findByPhoneNumber(String phoneNumber);
 
-    default Customer findByEmailOrThrow(String email) {
-        return findByEmail(email).orElseThrow(
+    default Customer findByIdOrThrow(Long customerId) {
+        return findById(customerId).orElseThrow(
             () -> new CustomerNotFoundException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/sparta/goodbite/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/controller/ReviewController.java
@@ -1,5 +1,6 @@
 package com.sparta.goodbite.domain.review.controller;
 
+import com.sparta.goodbite.auth.security.EmailUserDetails;
 import com.sparta.goodbite.common.response.DataResponseDto;
 import com.sparta.goodbite.common.response.MessageResponseDto;
 import com.sparta.goodbite.common.response.ResponseUtil;
@@ -11,6 +12,8 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,11 +30,13 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
+    @PreAuthorize("hasRole('CUSTOMER')")
     @PostMapping
     public ResponseEntity<MessageResponseDto> createReview(
-        @Valid @RequestBody CreateReviewRequestDto createReviewRequestDto) {
+        @Valid @RequestBody CreateReviewRequestDto createReviewRequestDto,
+        @AuthenticationPrincipal EmailUserDetails userDetails) {
 
-        reviewService.createReview(createReviewRequestDto);
+        reviewService.createReview(createReviewRequestDto, userDetails.getUser());
         return ResponseUtil.createOk();
     }
 
@@ -47,17 +52,22 @@ public class ReviewController {
         return ResponseUtil.findOk(reviewService.getAllReviews());
     }
 
+    @PreAuthorize("hasRole('CUSTOMER')")
     @PutMapping("/{reviewId}")
     public ResponseEntity<MessageResponseDto> updateReview(@PathVariable Long reviewId,
-        @Valid @RequestBody UpdateReviewRequestDto updateReviewRequestDto) {
+        @Valid @RequestBody UpdateReviewRequestDto updateReviewRequestDto,
+        @AuthenticationPrincipal EmailUserDetails userDetails) {
 
-        reviewService.updateReview(reviewId, updateReviewRequestDto);
+        reviewService.updateReview(reviewId, updateReviewRequestDto, userDetails.getUser());
         return ResponseUtil.updateOk();
     }
 
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'ADMIN')")
     @DeleteMapping("/{reviewId}")
-    public ResponseEntity<MessageResponseDto> deleteReview(@PathVariable Long reviewId) {
-        reviewService.deleteReview(reviewId);
+    public ResponseEntity<MessageResponseDto> deleteReview(@PathVariable Long reviewId,
+        @AuthenticationPrincipal EmailUserDetails userDetails) {
+
+        reviewService.deleteReview(reviewId, userDetails.getUser());
         return ResponseUtil.deleteOk();
     }
 }

--- a/src/main/java/com/sparta/goodbite/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/controller/ReviewController.java
@@ -40,6 +40,7 @@ public class ReviewController {
         return ResponseUtil.createOk();
     }
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/{reviewId}")
     public ResponseEntity<DataResponseDto<ReviewResponseDto>> getReview(
         @PathVariable Long reviewId) {
@@ -47,6 +48,7 @@ public class ReviewController {
         return ResponseUtil.findOk(reviewService.getReview(reviewId));
     }
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping
     public ResponseEntity<DataResponseDto<List<ReviewResponseDto>>> getAllReviews() {
         return ResponseUtil.findOk(reviewService.getAllReviews());

--- a/src/main/java/com/sparta/goodbite/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/controller/ReviewController.java
@@ -40,7 +40,6 @@ public class ReviewController {
         return ResponseUtil.createOk();
     }
 
-    @PreAuthorize("isAuthenticated()")
     @GetMapping("/{reviewId}")
     public ResponseEntity<DataResponseDto<ReviewResponseDto>> getReview(
         @PathVariable Long reviewId) {
@@ -48,7 +47,6 @@ public class ReviewController {
         return ResponseUtil.findOk(reviewService.getReview(reviewId));
     }
 
-    @PreAuthorize("isAuthenticated()")
     @GetMapping
     public ResponseEntity<DataResponseDto<List<ReviewResponseDto>>> getAllReviews() {
         return ResponseUtil.findOk(reviewService.getAllReviews());

--- a/src/main/java/com/sparta/goodbite/domain/review/dto/CreateReviewRequestDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/dto/CreateReviewRequestDto.java
@@ -1,7 +1,7 @@
 package com.sparta.goodbite.domain.review.dto;
 
 import com.sparta.goodbite.domain.customer.entity.Customer;
-import com.sparta.goodbite.domain.menu.entity.Menu;
+import com.sparta.goodbite.domain.restaurant.entity.Restaurant;
 import com.sparta.goodbite.domain.review.dto.validation.constraint.RatingConstraint;
 import com.sparta.goodbite.domain.review.entity.Review;
 import jakarta.validation.constraints.NotNull;
@@ -10,8 +10,8 @@ import lombok.Getter;
 @Getter
 public class CreateReviewRequestDto {
 
-    @NotNull(message = "메뉴 ID를 입력해 주세요.")
-    private Long menuId;
+    @NotNull(message = "식당 ID를 입력해 주세요.")
+    private Long restaurantId;
 
     @NotNull(message = "평점을 입력해 주세요.")
     @RatingConstraint
@@ -20,11 +20,11 @@ public class CreateReviewRequestDto {
     @NotNull(message = "리뷰 내용을 입력해 주세요.")
     private String content;
 
-    public Review toEntity(Menu menu, Customer customer) {
+    public Review toEntity(Restaurant restaurant, Customer customer) {
         return Review.builder()
             .rating(rating)
             .content(content)
-            .menu(menu)
+            .restaurant(restaurant)
             .customer(customer)
             .build();
     }

--- a/src/main/java/com/sparta/goodbite/domain/review/dto/CreateReviewRequestDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/dto/CreateReviewRequestDto.java
@@ -1,5 +1,6 @@
 package com.sparta.goodbite.domain.review.dto;
 
+import com.sparta.goodbite.domain.customer.entity.Customer;
 import com.sparta.goodbite.domain.menu.entity.Menu;
 import com.sparta.goodbite.domain.review.dto.validation.constraint.RatingConstraint;
 import com.sparta.goodbite.domain.review.entity.Review;
@@ -19,11 +20,12 @@ public class CreateReviewRequestDto {
     @NotNull(message = "리뷰 내용을 입력해 주세요.")
     private String content;
 
-    public Review toEntity(Menu menu) {
+    public Review toEntity(Menu menu, Customer customer) {
         return Review.builder()
             .rating(rating)
             .content(content)
             .menu(menu)
+            .customer(customer)
             .build();
     }
 }

--- a/src/main/java/com/sparta/goodbite/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/dto/ReviewResponseDto.java
@@ -2,10 +2,11 @@ package com.sparta.goodbite.domain.review.dto;
 
 import com.sparta.goodbite.domain.review.entity.Review;
 
-public record ReviewResponseDto(Long menuId, float rating, String content) {
+public record ReviewResponseDto(Long reviewId, Long menuId, float rating, String content) {
 
     public static ReviewResponseDto from(Review review) {
         return new ReviewResponseDto(
+            review.getId(),
             review.getMenu().getId(),
             review.getRating(),
             review.getContent());

--- a/src/main/java/com/sparta/goodbite/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/dto/ReviewResponseDto.java
@@ -2,12 +2,12 @@ package com.sparta.goodbite.domain.review.dto;
 
 import com.sparta.goodbite.domain.review.entity.Review;
 
-public record ReviewResponseDto(Long reviewId, Long menuId, float rating, String content) {
+public record ReviewResponseDto(Long reviewId, Long restaurantId, float rating, String content) {
 
     public static ReviewResponseDto from(Review review) {
         return new ReviewResponseDto(
             review.getId(),
-            review.getMenu().getId(),
+            review.getRestaurant().getId(),
             review.getRating(),
             review.getContent());
     }

--- a/src/main/java/com/sparta/goodbite/domain/review/entity/Review.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/entity/Review.java
@@ -2,7 +2,7 @@ package com.sparta.goodbite.domain.review.entity;
 
 import com.sparta.goodbite.common.Timestamped;
 import com.sparta.goodbite.domain.customer.entity.Customer;
-import com.sparta.goodbite.domain.menu.entity.Menu;
+import com.sparta.goodbite.domain.restaurant.entity.Restaurant;
 import com.sparta.goodbite.domain.review.dto.UpdateReviewRequestDto;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -31,18 +31,18 @@ public class Review extends Timestamped {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "menu_id", nullable = false)
-    private Menu menu;
+    @JoinColumn(name = "restaurant_id", nullable = false)
+    private Restaurant restaurant;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "customer_id", nullable = false)
     private Customer customer;
 
     @Builder
-    public Review(float rating, String content, Menu menu, Customer customer) {
+    public Review(float rating, String content, Restaurant restaurant, Customer customer) {
         this.rating = rating;
         this.content = content;
-        this.menu = menu;
+        this.restaurant = restaurant;
         this.customer = customer;
     }
 

--- a/src/main/java/com/sparta/goodbite/domain/review/entity/Review.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/entity/Review.java
@@ -1,6 +1,7 @@
 package com.sparta.goodbite.domain.review.entity;
 
 import com.sparta.goodbite.common.Timestamped;
+import com.sparta.goodbite.domain.customer.entity.Customer;
 import com.sparta.goodbite.domain.menu.entity.Menu;
 import com.sparta.goodbite.domain.review.dto.UpdateReviewRequestDto;
 import jakarta.persistence.Entity;
@@ -33,15 +34,16 @@ public class Review extends Timestamped {
     @JoinColumn(name = "menu_id", nullable = false)
     private Menu menu;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "customer_id", nullable = false)
-//    private Customer customer;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id", nullable = false)
+    private Customer customer;
 
     @Builder
-    public Review(float rating, String content, Menu menu) {
+    public Review(float rating, String content, Menu menu, Customer customer) {
         this.rating = rating;
         this.content = content;
         this.menu = menu;
+        this.customer = customer;
     }
 
     public void update(UpdateReviewRequestDto updateReviewRequestDto) {

--- a/src/main/java/com/sparta/goodbite/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/service/ReviewService.java
@@ -29,8 +29,7 @@ public class ReviewService {
     public void createReview(CreateReviewRequestDto createReviewRequestDto, UserCredentials user) {
         Restaurant restaurant = restaurantRepository.findByIdOrThrow(
             createReviewRequestDto.getRestaurantId());
-        Customer customer = customerRepository.findByIdOrThrow(user.getId());
-        reviewRepository.save(createReviewRequestDto.toEntity(restaurant, customer));
+        reviewRepository.save(createReviewRequestDto.toEntity(restaurant, (Customer) user));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/sparta/goodbite/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/service/ReviewService.java
@@ -1,5 +1,7 @@
 package com.sparta.goodbite.domain.review.service;
 
+import com.sparta.goodbite.common.UserCredentials;
+import com.sparta.goodbite.domain.customer.entity.Customer;
 import com.sparta.goodbite.domain.menu.entity.Menu;
 import com.sparta.goodbite.domain.menu.repository.MenuRepository;
 import com.sparta.goodbite.domain.review.dto.CreateReviewRequestDto;
@@ -20,9 +22,10 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
 
     @Transactional
-    public void createReview(CreateReviewRequestDto createReviewRequestDto) {
+    public void createReview(CreateReviewRequestDto createReviewRequestDto, UserCredentials user) {
         Menu menu = menuRepository.findByIdOrThrow(createReviewRequestDto.getMenuId());
-        reviewRepository.save(createReviewRequestDto.toEntity(menu));
+        Customer customer = null;
+        reviewRepository.save(createReviewRequestDto.toEntity(menu, customer));
     }
 
     @Transactional(readOnly = true)
@@ -36,13 +39,15 @@ public class ReviewService {
     }
 
     @Transactional
-    public void updateReview(Long reviewId, UpdateReviewRequestDto updateReviewRequestDto) {
+    public void updateReview(Long reviewId, UpdateReviewRequestDto updateReviewRequestDto,
+        UserCredentials user) {
+
         Review review = reviewRepository.findByIdOrThrow(reviewId);
         review.update(updateReviewRequestDto);
     }
 
     @Transactional
-    public void deleteReview(Long reviewId) {
+    public void deleteReview(Long reviewId, UserCredentials user) {
         Review review = reviewRepository.findByIdOrThrow(reviewId);
         reviewRepository.delete(review);
     }

--- a/src/main/java/com/sparta/goodbite/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/service/ReviewService.java
@@ -28,7 +28,7 @@ public class ReviewService {
     @Transactional
     public void createReview(CreateReviewRequestDto createReviewRequestDto, UserCredentials user) {
         Menu menu = menuRepository.findByIdOrThrow(createReviewRequestDto.getMenuId());
-        Customer customer = customerRepository.findByEmailOrThrow(user.getEmail());
+        Customer customer = customerRepository.findByIdOrThrow(user.getId());
         reviewRepository.save(createReviewRequestDto.toEntity(menu, customer));
     }
 
@@ -58,9 +58,8 @@ public class ReviewService {
 
     private Review getReviewByIdAndValidateCustomer(Long reviewId, UserCredentials user) {
         Review review = reviewRepository.findByIdOrThrow(reviewId);
-        Customer customer = customerRepository.findByEmailOrThrow(user.getEmail());
 
-        if (!review.getCustomer().getId().equals(customer.getId())) {
+        if (!review.getCustomer().getId().equals(user.getId())) {
             throw new AuthException(AuthErrorCode.UNAUTHORIZED);
         }
 

--- a/src/main/java/com/sparta/goodbite/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/service/ReviewService.java
@@ -3,8 +3,8 @@ package com.sparta.goodbite.domain.review.service;
 import com.sparta.goodbite.common.UserCredentials;
 import com.sparta.goodbite.domain.customer.entity.Customer;
 import com.sparta.goodbite.domain.customer.repository.CustomerRepository;
-import com.sparta.goodbite.domain.menu.entity.Menu;
-import com.sparta.goodbite.domain.menu.repository.MenuRepository;
+import com.sparta.goodbite.domain.restaurant.entity.Restaurant;
+import com.sparta.goodbite.domain.restaurant.repository.RestaurantRepository;
 import com.sparta.goodbite.domain.review.dto.CreateReviewRequestDto;
 import com.sparta.goodbite.domain.review.dto.ReviewResponseDto;
 import com.sparta.goodbite.domain.review.dto.UpdateReviewRequestDto;
@@ -21,15 +21,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ReviewService {
 
-    private final MenuRepository menuRepository;
+    private final RestaurantRepository restaurantRepository;
     private final ReviewRepository reviewRepository;
     private final CustomerRepository customerRepository;
 
     @Transactional
     public void createReview(CreateReviewRequestDto createReviewRequestDto, UserCredentials user) {
-        Menu menu = menuRepository.findByIdOrThrow(createReviewRequestDto.getMenuId());
+        Restaurant restaurant = restaurantRepository.findByIdOrThrow(
+            createReviewRequestDto.getRestaurantId());
         Customer customer = customerRepository.findByIdOrThrow(user.getId());
-        reviewRepository.save(createReviewRequestDto.toEntity(menu, customer));
+        reviewRepository.save(createReviewRequestDto.toEntity(restaurant, customer));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/sparta/goodbite/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/service/ReviewService.java
@@ -2,6 +2,7 @@ package com.sparta.goodbite.domain.review.service;
 
 import com.sparta.goodbite.common.UserCredentials;
 import com.sparta.goodbite.domain.customer.entity.Customer;
+import com.sparta.goodbite.domain.customer.repository.CustomerRepository;
 import com.sparta.goodbite.domain.menu.entity.Menu;
 import com.sparta.goodbite.domain.menu.repository.MenuRepository;
 import com.sparta.goodbite.domain.review.dto.CreateReviewRequestDto;
@@ -9,6 +10,8 @@ import com.sparta.goodbite.domain.review.dto.ReviewResponseDto;
 import com.sparta.goodbite.domain.review.dto.UpdateReviewRequestDto;
 import com.sparta.goodbite.domain.review.entity.Review;
 import com.sparta.goodbite.domain.review.repository.ReviewRepository;
+import com.sparta.goodbite.exception.auth.AuthErrorCode;
+import com.sparta.goodbite.exception.auth.AuthException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,11 +23,12 @@ public class ReviewService {
 
     private final MenuRepository menuRepository;
     private final ReviewRepository reviewRepository;
+    private final CustomerRepository customerRepository;
 
     @Transactional
     public void createReview(CreateReviewRequestDto createReviewRequestDto, UserCredentials user) {
         Menu menu = menuRepository.findByIdOrThrow(createReviewRequestDto.getMenuId());
-        Customer customer = null;
+        Customer customer = customerRepository.findByEmailOrThrow(user.getEmail());
         reviewRepository.save(createReviewRequestDto.toEntity(menu, customer));
     }
 
@@ -42,13 +46,24 @@ public class ReviewService {
     public void updateReview(Long reviewId, UpdateReviewRequestDto updateReviewRequestDto,
         UserCredentials user) {
 
-        Review review = reviewRepository.findByIdOrThrow(reviewId);
+        Review review = getReviewByIdAndValidateCustomer(reviewId, user);
         review.update(updateReviewRequestDto);
     }
 
     @Transactional
     public void deleteReview(Long reviewId, UserCredentials user) {
-        Review review = reviewRepository.findByIdOrThrow(reviewId);
+        Review review = getReviewByIdAndValidateCustomer(reviewId, user);
         reviewRepository.delete(review);
+    }
+
+    private Review getReviewByIdAndValidateCustomer(Long reviewId, UserCredentials user) {
+        Review review = reviewRepository.findByIdOrThrow(reviewId);
+        Customer customer = customerRepository.findByEmailOrThrow(user.getEmail());
+
+        if (!review.getCustomer().getId().equals(customer.getId())) {
+            throw new AuthException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        return review;
     }
 }


### PR DESCRIPTION
제목 : [♻️REFACTOR] 리뷰 도메인 인증/인가 적용
feat(issue 번호): #71 

## 🔎 작업 내용
- 리뷰 도메인에 인증/인가 적용
- 사용자를 `email`이 아닌 `UserCredentials` 인터페이스의 `getId` 메서드로 조회
- `@PreAuthorize` 애너테이션을 사용하여 메서드 수준의 인가 설정
- WebSecurityConfig 파일에 `@EnableMethodSecurity` 설정


## 🔗 이슈 링크

- [x] #72 
- [x] #73 
- [x] #74 

resolved: #72 #73 #74
