### PR TITLE
112 front waiting waiting 삭제를 위한 코드수정

### DIFF
--- a/http/waiting.http
+++ b/http/waiting.http
@@ -21,7 +21,7 @@ POST {{baseUrl}}/waitings
 Content-Type: application/json
 
 {
-  "restaurantId": 3,
+  "restaurantId": 2,
   "partySize": 123,
   "waitingType": "OFFLINE",
   "demand": "널널한 자리로 주세요~"
@@ -57,7 +57,7 @@ PUT {{baseUrl}}/restaurants/{{restaurantId}}/waitings
 
 
 ### Waiting 사장이 하나만 수락하고 그 뒤 가게 Waiting 순서 하나씩 줄어들게 하는거
-PUT {{baseUrl}}/restaurants/waitings/{{waitingId}}
+PUT {{baseUrl}}/restaurants/waitings/5
 
 ### 가게 웨이팅 리스트 페이지네이션 해서 보기
 GET {{baseUrl}}/restaurants/{{restaurantId}}/waitingList?page=0&size=5

--- a/src/main/java/com/sparta/goodbite/domain/waiting/entity/Waiting.java
+++ b/src/main/java/com/sparta/goodbite/domain/waiting/entity/Waiting.java
@@ -1,6 +1,6 @@
 package com.sparta.goodbite.domain.waiting.entity;
 
-import com.sparta.goodbite.common.Timestamped;
+import com.sparta.goodbite.common.ExtendedTimestamped;
 import com.sparta.goodbite.domain.customer.entity.Customer;
 import com.sparta.goodbite.domain.restaurant.entity.Restaurant;
 import jakarta.persistence.Column;
@@ -13,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Entity
-public class Waiting extends Timestamped {
+public class Waiting extends ExtendedTimestamped {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -65,6 +66,12 @@ public class Waiting extends Timestamped {
     public void update(Long partySize, String demand) {
         this.partySize = partySize;
         this.demand = demand;
+    }
+
+    public void setDeleted(LocalDateTime deletedAt, WaitingStatus status) {
+        this.waitingOrder = 0L;
+        this.deletedAt = deletedAt;
+        this.status = status;
     }
 
     public void reduceWaitingOrder() {

--- a/src/main/java/com/sparta/goodbite/domain/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/sparta/goodbite/domain/waiting/repository/WaitingRepository.java
@@ -15,18 +15,27 @@ import org.springframework.data.repository.query.Param;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 
+    // 삭제된 것 까지 조회함. 주의
     default Waiting findByIdOrThrow(Long waitingId) {
         return findById(waitingId).orElseThrow(
             () -> new WaitingException(WaitingErrorCode.WAITING_NOT_FOUND));
     }
 
+    default Waiting findByIdAndDeletedAt(Long waitingId) {
+        return findByIdAndDeletedAtIsNull(waitingId)
+            .orElseThrow(() -> new WaitingException(WaitingErrorCode.WAITING_NOT_FOUND));
+    }
+
+    @Query("SELECT w FROM Waiting w WHERE w.restaurant.id = :restaurantId AND w.customer.id = :customerId AND w.deletedAt IS NULL")
     Optional<Waiting> findByRestaurantIdAndCustomerId(Long restaurantId, Long customerId);
 
+    @Query("SELECT w FROM Waiting w WHERE w.restaurant.id = :restaurantId AND w.deletedAt IS NULL")
     ArrayList<Waiting> findALLByRestaurantId(Long restaurantId);
 
-    @Query("SELECT MAX(w.waitingOrder) FROM Waiting w WHERE w.restaurant.id = :restaurant_id")
+    @Query("SELECT MAX(w.waitingOrder) FROM Waiting w WHERE w.restaurant.id = :restaurant_id AND w.deletedAt IS NULL")
     Long findMaxWaitingOrderByRestaurantId(@Param("restaurant_id") Long restaurant_id);
 
+    @Query("SELECT w FROM Waiting w WHERE w.restaurant.id = :restaurantId AND w.deletedAt IS NULL")
     Page<Waiting> findByRestaurantId(Long restaurantId, Pageable pageable);
 
     default void validateRestaurantIdAndCustomerId(Long restaurantId, Long customerId) {
@@ -42,4 +51,7 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
         }
         return waitings;
     }
+
+    @Query("SELECT w FROM Waiting w WHERE w.id = :waitingId AND w.deletedAt IS NULL")
+    Optional<Waiting> findByIdAndDeletedAtIsNull(@Param("waitingId") Long waitingId);
 }


### PR DESCRIPTION
제목 : [🩹FIX] waiting 삭제를 위한 코드수정
feat(issue 번호):

## 🔎 작업 내용
- waiting을 soft-delete 할 수 있도록 수정
- waiting을 식당에서 받는 상황과 삭제/취소 상황 발생 시, waiting의 status를 변경하도록 수정
- 삭제/취소 기능 실행 시, status가 수정되고 waiting의 deletedAt필드가 수정됨

## 🔗 이슈 링크

- [ ] #116 

resolved: #116
