### PR TITLE
✨ feat: 로그인 성공시 응답본문으로 메세지와 함께 인증객체의 Role전달

### DIFF
--- a/src/main/java/com/sparta/goodbite/auth/dto/LoginSuccessResponseDto.java
+++ b/src/main/java/com/sparta/goodbite/auth/dto/LoginSuccessResponseDto.java
@@ -1,0 +1,8 @@
+package com.sparta.goodbite.auth.dto;
+
+public record LoginSuccessResponseDto(String message, String role) {
+
+    public static LoginSuccessResponseDto from(String message, String role) {
+        return new LoginSuccessResponseDto(message, role);
+    }
+}

--- a/src/main/java/com/sparta/goodbite/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/goodbite/auth/security/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.sparta.goodbite.auth.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.goodbite.auth.dto.LoginRequestDto;
+import com.sparta.goodbite.auth.dto.LoginSuccessResponseDto;
 import com.sparta.goodbite.auth.util.JwtUtil;
 import com.sparta.goodbite.common.response.ResponseUtil;
 import jakarta.servlet.FilterChain;
@@ -102,6 +103,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
         String email = ((EmailUserDetails) authResult.getPrincipal()).getEmail();
         String role = ((EmailUserDetails) authResult.getPrincipal()).getRole();
+        //String nickname = ((EmailUserDetails) authResult.getPrincipal()).get
 
         String accessToken = JwtUtil.createAccessToken(email, role);
         String refreshToken = JwtUtil.createRefreshToken(email, role);
@@ -109,7 +111,10 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         JwtUtil.addJwtToCookie(accessToken, response);
         JwtUtil.addJwtToCookie(refreshToken, response);
 
-        ResponseUtil.servletApi(response, HttpStatus.OK.value(), "로그인 성공");
+        // 사용자 역할 정보를 포함한 응답 생성
+        LoginSuccessResponseDto responseDto = LoginSuccessResponseDto.from("로그인 성공", role);
+
+        ResponseUtil.servletApi(response, HttpStatus.OK.value(), responseDto);
     }
 
     @Override

--- a/src/main/java/com/sparta/goodbite/common/response/ResponseUtil.java
+++ b/src/main/java/com/sparta/goodbite/common/response/ResponseUtil.java
@@ -71,4 +71,26 @@ public abstract class ResponseUtil {
         // 응답 데이터 반환
         response.getWriter().write(result);
     }
+
+    /**
+     * 서블릿 컨테이너를 거치지 않고 사용자에게 응답 메시지와 데이터를 반환
+     *
+     * @param response   서블릿 응답 객체
+     * @param httpStatus 응답 http 상태
+     * @param data       응답 데이터
+     * @throws IOException JSON <-> 객체 매핑 예외처리
+     */
+    public static void servletApi(HttpServletResponse response, int httpStatus, Object data)
+        throws IOException {
+        // 응답 상태 설정
+        response.setStatus(httpStatus);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+
+        // 응답 데이터 설정
+        String result = new ObjectMapper().writeValueAsString(data);
+
+        // 응답 데이터 반환
+        response.getWriter().write(result);
+    }
 }


### PR DESCRIPTION
제목 : [✨FEAT] 로그인 성공시 응답본문으로 메세지와 함께 인증객체의 Role전달
feat(issue 번호): 143

## 🔎 작업 내용
- 응답 Dto 생성
- 필터에서 successfulAuthentication 수정하여 사용자 역할정보를 포함한 응답 생성
- 데이터를 응답으로 주는 servletApi메서드를 ResponseUtil추가

## 🔗 이슈 링크

- [x] #143 
- [x] #147

resolved: #143, resolved: #147
