### PR TITLE
119 feat customerowner 비밀번호 이중입력 기능 추가

### DIFF
--- a/src/main/java/com/sparta/goodbite/common/validation/constraint/InputPasswordMatchesConstraint.java
+++ b/src/main/java/com/sparta/goodbite/common/validation/constraint/InputPasswordMatchesConstraint.java
@@ -1,0 +1,21 @@
+package com.sparta.goodbite.common.validation.constraint;
+
+import com.sparta.goodbite.common.validation.validator.InputPasswordMatchesValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = InputPasswordMatchesValidator.class)
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InputPasswordMatchesConstraint {
+
+    String message() default "비밀번호 확인이 비밀번호와 일치하지 않습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/sparta/goodbite/common/validation/validator/InputPasswordMatchesValidator.java
+++ b/src/main/java/com/sparta/goodbite/common/validation/validator/InputPasswordMatchesValidator.java
@@ -1,0 +1,33 @@
+package com.sparta.goodbite.common.validation.validator;
+
+import com.sparta.goodbite.common.validation.constraint.InputPasswordMatchesConstraint;
+import com.sparta.goodbite.domain.customer.dto.CustomerSignupRequestDto;
+import com.sparta.goodbite.domain.customer.dto.UpdateCustomerPasswordRequestDto;
+import com.sparta.goodbite.domain.owner.dto.OwnerSignUpRequestDto;
+import com.sparta.goodbite.domain.owner.dto.UpdateOwnerPasswordRequestDto;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class InputPasswordMatchesValidator implements
+    ConstraintValidator<InputPasswordMatchesConstraint, Object> {
+
+    @Override
+    public boolean isValid(Object obj, ConstraintValidatorContext context) {
+
+        return switch (obj) {
+            case OwnerSignUpRequestDto dto -> dto.getPassword().equals(dto.getConfirmedPassword());
+            case CustomerSignupRequestDto dto ->
+                dto.getPassword().equals(dto.getConfirmedPassword());
+            case UpdateOwnerPasswordRequestDto dto ->
+                dto.getNewPassword().equals(dto.getConfirmedNewPassword());
+            case UpdateCustomerPasswordRequestDto dto ->
+                dto.getNewPassword().equals(dto.getConfirmedNewPassword());
+            default -> {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate("유효하지 않은 요청 DTO입니다.")
+                    .addConstraintViolation();
+                yield false;
+            }
+        };
+    }
+}

--- a/src/main/java/com/sparta/goodbite/domain/customer/controller/CustomerController.java
+++ b/src/main/java/com/sparta/goodbite/domain/customer/controller/CustomerController.java
@@ -6,8 +6,8 @@ import com.sparta.goodbite.common.response.MessageResponseDto;
 import com.sparta.goodbite.common.response.ResponseUtil;
 import com.sparta.goodbite.domain.customer.dto.CustomerResponseDto;
 import com.sparta.goodbite.domain.customer.dto.CustomerSignupRequestDto;
+import com.sparta.goodbite.domain.customer.dto.UpdateCustomerPasswordRequestDto;
 import com.sparta.goodbite.domain.customer.dto.UpdateNicknameRequestDto;
-import com.sparta.goodbite.domain.customer.dto.UpdatePasswordRequestDto;
 import com.sparta.goodbite.domain.customer.dto.UpdatePhoneNumberRequestDto;
 import com.sparta.goodbite.domain.customer.entity.Customer;
 import com.sparta.goodbite.domain.customer.service.CustomerService;
@@ -79,7 +79,7 @@ public class CustomerController {
      */
     @PatchMapping("/password")
     public ResponseEntity<MessageResponseDto> updatePassword(
-        @Valid @RequestBody UpdatePasswordRequestDto requestDto,
+        @Valid @RequestBody UpdateCustomerPasswordRequestDto requestDto,
         @AuthenticationPrincipal EmailUserDetails userDetails) {
         customerService.updatePassword(requestDto, (Customer) userDetails.getUser());
         return ResponseUtil.updateOk();

--- a/src/main/java/com/sparta/goodbite/domain/customer/dto/CustomerSignupRequestDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/customer/dto/CustomerSignupRequestDto.java
@@ -1,5 +1,6 @@
 package com.sparta.goodbite.domain.customer.dto;
 
+import com.sparta.goodbite.common.validation.constraint.InputPasswordMatchesConstraint;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -7,6 +8,7 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
+@InputPasswordMatchesConstraint
 public class CustomerSignupRequestDto {
 
     @Email(regexp = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
@@ -24,6 +26,9 @@ public class CustomerSignupRequestDto {
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
         message = "비밀번호는 알파벳 대소문자, 숫자, 특수문자로 구성되어야 합니다.")
     private String password;
+
+    @NotBlank(message = "비밀번호 확인을 입력해 주세요.")
+    private String confirmedPassword;
 
     @NotBlank(message = "휴대폰번호를 입력해 주세요.")
     @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 양식에 맞지 않습니다. ex) 010-0000-0000\n")

--- a/src/main/java/com/sparta/goodbite/domain/customer/dto/UpdateCustomerPasswordRequestDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/customer/dto/UpdateCustomerPasswordRequestDto.java
@@ -1,12 +1,14 @@
 package com.sparta.goodbite.domain.customer.dto;
 
+import com.sparta.goodbite.common.validation.constraint.InputPasswordMatchesConstraint;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
-public class UpdatePasswordRequestDto {
+@InputPasswordMatchesConstraint
+public class UpdateCustomerPasswordRequestDto {
 
     @NotBlank(message = "현재 비밀번호를 입력해주세요.")
     private String currentPassword;
@@ -16,4 +18,7 @@ public class UpdatePasswordRequestDto {
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
         message = "비밀번호는 알파벳 대소문자, 숫자, 특수문자로 구성되어야 합니다.")
     private String newPassword;
+
+    @NotBlank(message = "새 비밀번호 확인을 입력해 주세요.")
+    private String confirmedNewPassword;
 }

--- a/src/main/java/com/sparta/goodbite/domain/customer/service/CustomerService.java
+++ b/src/main/java/com/sparta/goodbite/domain/customer/service/CustomerService.java
@@ -2,8 +2,8 @@ package com.sparta.goodbite.domain.customer.service;
 
 import com.sparta.goodbite.domain.customer.dto.CustomerResponseDto;
 import com.sparta.goodbite.domain.customer.dto.CustomerSignupRequestDto;
+import com.sparta.goodbite.domain.customer.dto.UpdateCustomerPasswordRequestDto;
 import com.sparta.goodbite.domain.customer.dto.UpdateNicknameRequestDto;
-import com.sparta.goodbite.domain.customer.dto.UpdatePasswordRequestDto;
 import com.sparta.goodbite.domain.customer.dto.UpdatePhoneNumberRequestDto;
 import com.sparta.goodbite.domain.customer.entity.Customer;
 import com.sparta.goodbite.domain.customer.repository.CustomerRepository;
@@ -71,7 +71,7 @@ public class CustomerService {
 
     //수정-비밀번호
     @Transactional
-    public void updatePassword(UpdatePasswordRequestDto requestDto, Customer customer) {
+    public void updatePassword(UpdateCustomerPasswordRequestDto requestDto, Customer customer) {
 
         //입력한 비밀번호와 사용자의 비밀번호 일치유무 확인
         if (!passwordEncoder.matches(requestDto.getCurrentPassword(), customer.getPassword())) {

--- a/src/main/java/com/sparta/goodbite/domain/owner/dto/OwnerSignUpRequestDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/owner/dto/OwnerSignUpRequestDto.java
@@ -1,5 +1,6 @@
 package com.sparta.goodbite.domain.owner.dto;
 
+import com.sparta.goodbite.common.validation.constraint.InputPasswordMatchesConstraint;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -7,6 +8,7 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
+@InputPasswordMatchesConstraint
 public class OwnerSignUpRequestDto {
 
     @Email(regexp = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
@@ -24,6 +26,9 @@ public class OwnerSignUpRequestDto {
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
         message = "비밀번호는 알파벳 대소문자, 숫자, 특수문자로 구성되어야 합니다.")
     private String password;
+
+    @NotBlank(message = "비밀번호 확인을 입력해 주세요.")
+    private String confirmedPassword;
 
     @NotBlank(message = "휴대폰 번호를 입력해 주세요.")
     @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 양식에 맞지 않습니다. ex) 010-0000-0000\n")

--- a/src/main/java/com/sparta/goodbite/domain/owner/dto/UpdateOwnerPasswordRequestDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/owner/dto/UpdateOwnerPasswordRequestDto.java
@@ -1,11 +1,13 @@
 package com.sparta.goodbite.domain.owner.dto;
 
+import com.sparta.goodbite.common.validation.constraint.InputPasswordMatchesConstraint;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
+@InputPasswordMatchesConstraint
 public class UpdateOwnerPasswordRequestDto {
 
     @NotBlank(message = "현재 비밀번호를 입력해주세요.")
@@ -16,4 +18,7 @@ public class UpdateOwnerPasswordRequestDto {
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
         message = "비밀번호는 알파벳 대소문자, 숫자, 특수문자로 구성되어야 합니다.")
     private String newPassword;
+
+    @NotBlank(message = "새 비밀번호 확인을 입력해 주세요.")
+    private String confirmedNewPassword;
 }


### PR DESCRIPTION
제목 : [✨FEAT] / Customer 및 Owner 비밀번호 이중입력 기능 추가
feat(issue 번호): #162 #163

## 🔎 작업 내용

- 비밀번호 재확인 및 일치 커스텀 유효성 검증 추가
- Customer 및 Owner 도메인의 관련 요청 DTO에 적용
- Customer 비밀번호 변경 요청 DTO명 수정
  - `UpdatePasswordRequestDto` -> `UpdateCustomerPasswordRequestDto`
  - Owner의 비밀번호 변경 요청 DTO명은 `UpdateOwnerPasswordRequestDto`이기 때문에 일관되도록 수정
- **변경된 요청 DTO 양식에 따라 반드시 프론트엔드 폼 변경 필요**

## 🔗 이슈 링크

- [x] #162
- [x] #163

resolved: #119
