### PR TITLE
165 refactor 패키지 구조 리팩토링

### DIFF
--- a/src/main/java/com/sparta/goodbite/common/util/JwtUtil.java
+++ b/src/main/java/com/sparta/goodbite/common/util/JwtUtil.java
@@ -1,5 +1,6 @@
-package com.sparta.goodbite.auth.util;
+package com.sparta.goodbite.common.util;
 
+import com.sparta.goodbite.config.JwtConfig;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;

--- a/src/main/java/com/sparta/goodbite/common/util/ResponseUtil.java
+++ b/src/main/java/com/sparta/goodbite/common/util/ResponseUtil.java
@@ -1,6 +1,8 @@
-package com.sparta.goodbite.common.response;
+package com.sparta.goodbite.common.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.goodbite.common.response.DataResponseDto;
+import com.sparta.goodbite.common.response.MessageResponseDto;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/sparta/goodbite/common/validation/constraint/AtLeastOneFieldConstraint.java
+++ b/src/main/java/com/sparta/goodbite/common/validation/constraint/AtLeastOneFieldConstraint.java
@@ -1,6 +1,6 @@
-package com.sparta.goodbite.domain.operatinghour.dto.validation.contraint;
+package com.sparta.goodbite.common.validation.constraint;
 
-import com.sparta.goodbite.domain.operatinghour.dto.validation.validator.OpenTimeBeforeCloseTimeValidator;
+import com.sparta.goodbite.common.validation.validator.AtLeastOneFieldValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
@@ -8,12 +8,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Constraint(validatedBy = OpenTimeBeforeCloseTimeValidator.class)
+@Constraint(validatedBy = AtLeastOneFieldValidator.class)
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface OpenTimeBeforeCloseTimeConstraint {
+public @interface AtLeastOneFieldConstraint {
 
-    String message() default "오픈 시간은 마감 시간보다 빨라야 합니다.";
+    String message() default "필드 중 적어도 하나는 비어 있지 않아야 합니다.";
 
     Class<?>[] groups() default {};
 

--- a/src/main/java/com/sparta/goodbite/common/validation/constraint/LocalTimeFormatConstraint.java
+++ b/src/main/java/com/sparta/goodbite/common/validation/constraint/LocalTimeFormatConstraint.java
@@ -1,6 +1,6 @@
-package com.sparta.goodbite.domain.operatinghour.dto.validation.contraint;
+package com.sparta.goodbite.common.validation.constraint;
 
-import com.sparta.goodbite.domain.operatinghour.dto.validation.validator.LocalTimeFormatValidator;
+import com.sparta.goodbite.common.validation.validator.LocalTimeFormatValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;

--- a/src/main/java/com/sparta/goodbite/common/validation/constraint/OpenTimeBeforeCloseTimeConstraint.java
+++ b/src/main/java/com/sparta/goodbite/common/validation/constraint/OpenTimeBeforeCloseTimeConstraint.java
@@ -1,6 +1,6 @@
-package com.sparta.goodbite.domain.menu.dto.validation.constraint;
+package com.sparta.goodbite.common.validation.constraint;
 
-import com.sparta.goodbite.domain.menu.dto.validation.validator.AtLeastOneFieldValidator;
+import com.sparta.goodbite.common.validation.validator.OpenTimeBeforeCloseTimeValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
@@ -8,12 +8,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Constraint(validatedBy = AtLeastOneFieldValidator.class)
+@Constraint(validatedBy = OpenTimeBeforeCloseTimeValidator.class)
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface AtLeastOneFieldConstraint {
+public @interface OpenTimeBeforeCloseTimeConstraint {
 
-    String message() default "필드 중 적어도 하나는 비어 있지 않아야 합니다.";
+    String message() default "오픈 시간은 마감 시간보다 빨라야 합니다.";
 
     Class<?>[] groups() default {};
 

--- a/src/main/java/com/sparta/goodbite/common/validation/constraint/RatingConstraint.java
+++ b/src/main/java/com/sparta/goodbite/common/validation/constraint/RatingConstraint.java
@@ -1,6 +1,6 @@
-package com.sparta.goodbite.domain.review.dto.validation.constraint;
+package com.sparta.goodbite.common.validation.constraint;
 
-import com.sparta.goodbite.domain.review.dto.validation.validator.RatingValidator;
+import com.sparta.goodbite.common.validation.validator.RatingValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;

--- a/src/main/java/com/sparta/goodbite/common/validation/validator/AtLeastOneFieldValidator.java
+++ b/src/main/java/com/sparta/goodbite/common/validation/validator/AtLeastOneFieldValidator.java
@@ -1,7 +1,7 @@
-package com.sparta.goodbite.domain.menu.dto.validation.validator;
+package com.sparta.goodbite.common.validation.validator;
 
+import com.sparta.goodbite.common.validation.constraint.AtLeastOneFieldConstraint;
 import com.sparta.goodbite.domain.menu.dto.UpdateMenuRequestDto;
-import com.sparta.goodbite.domain.menu.dto.validation.constraint.AtLeastOneFieldConstraint;
 import io.micrometer.common.util.StringUtils;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;

--- a/src/main/java/com/sparta/goodbite/common/validation/validator/LocalTimeFormatValidator.java
+++ b/src/main/java/com/sparta/goodbite/common/validation/validator/LocalTimeFormatValidator.java
@@ -1,6 +1,6 @@
-package com.sparta.goodbite.domain.operatinghour.dto.validation.validator;
+package com.sparta.goodbite.common.validation.validator;
 
-import com.sparta.goodbite.domain.operatinghour.dto.validation.contraint.LocalTimeFormatConstraint;
+import com.sparta.goodbite.common.validation.constraint.LocalTimeFormatConstraint;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.time.LocalTime;

--- a/src/main/java/com/sparta/goodbite/common/validation/validator/OpenTimeBeforeCloseTimeValidator.java
+++ b/src/main/java/com/sparta/goodbite/common/validation/validator/OpenTimeBeforeCloseTimeValidator.java
@@ -1,8 +1,8 @@
-package com.sparta.goodbite.domain.operatinghour.dto.validation.validator;
+package com.sparta.goodbite.common.validation.validator;
 
+import com.sparta.goodbite.common.validation.constraint.OpenTimeBeforeCloseTimeConstraint;
 import com.sparta.goodbite.domain.operatinghour.dto.CreateOperatingHourRequestDto;
 import com.sparta.goodbite.domain.operatinghour.dto.UpdateOperatingHourRequestDto;
-import com.sparta.goodbite.domain.operatinghour.dto.validation.contraint.OpenTimeBeforeCloseTimeConstraint;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.time.LocalTime;

--- a/src/main/java/com/sparta/goodbite/common/validation/validator/RatingValidator.java
+++ b/src/main/java/com/sparta/goodbite/common/validation/validator/RatingValidator.java
@@ -1,6 +1,6 @@
-package com.sparta.goodbite.domain.review.dto.validation.validator;
+package com.sparta.goodbite.common.validation.validator;
 
-import com.sparta.goodbite.domain.review.dto.validation.constraint.RatingConstraint;
+import com.sparta.goodbite.common.validation.constraint.RatingConstraint;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 

--- a/src/main/java/com/sparta/goodbite/config/CorsConfig.java
+++ b/src/main/java/com/sparta/goodbite/config/CorsConfig.java
@@ -1,4 +1,4 @@
-package com.sparta.goodbite.auth.security;
+package com.sparta.goodbite.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/sparta/goodbite/config/JwtConfig.java
+++ b/src/main/java/com/sparta/goodbite/config/JwtConfig.java
@@ -1,4 +1,4 @@
-package com.sparta.goodbite.auth.util;
+package com.sparta.goodbite.config;
 
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;

--- a/src/main/java/com/sparta/goodbite/config/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/goodbite/config/WebSecurityConfig.java
@@ -1,7 +1,13 @@
-package com.sparta.goodbite.auth.security;
+package com.sparta.goodbite.config;
 
-import com.sparta.goodbite.auth.UserRole;
-import com.sparta.goodbite.auth.util.JwtUtil;
+import com.sparta.goodbite.domain.auth.UserRole;
+import com.sparta.goodbite.security.EmailLogoutSuccessHandler;
+import com.sparta.goodbite.security.EmailUserDetailsService;
+import com.sparta.goodbite.security.GlobalAccessDeniedHandler;
+import com.sparta.goodbite.security.GlobalAuthenticationEntryPoint;
+import com.sparta.goodbite.security.JwtAuthenticationFilter;
+import com.sparta.goodbite.security.JwtAuthorizationFilter;
+import com.sparta.goodbite.common.util.JwtUtil;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/sparta/goodbite/config/WebSocketConfig.java
+++ b/src/main/java/com/sparta/goodbite/config/WebSocketConfig.java
@@ -1,4 +1,4 @@
-package com.sparta.goodbite.domain.waiting.config;
+package com.sparta.goodbite.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;

--- a/src/main/java/com/sparta/goodbite/domain/auth/UserRole.java
+++ b/src/main/java/com/sparta/goodbite/domain/auth/UserRole.java
@@ -1,4 +1,4 @@
-package com.sparta.goodbite.auth;
+package com.sparta.goodbite.domain.auth;
 
 import lombok.Getter;
 

--- a/src/main/java/com/sparta/goodbite/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/goodbite/domain/auth/controller/AuthController.java
@@ -1,8 +1,8 @@
-package com.sparta.goodbite.auth.controller;
+package com.sparta.goodbite.domain.auth.controller;
 
-import com.sparta.goodbite.auth.service.AuthService;
+import com.sparta.goodbite.domain.auth.service.AuthService;
 import com.sparta.goodbite.common.response.MessageResponseDto;
-import com.sparta.goodbite.common.response.ResponseUtil;
+import com.sparta.goodbite.common.util.ResponseUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/sparta/goodbite/domain/auth/dto/LoginRequestDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/auth/dto/LoginRequestDto.java
@@ -1,4 +1,4 @@
-package com.sparta.goodbite.auth.dto;
+package com.sparta.goodbite.domain.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/sparta/goodbite/domain/auth/dto/LoginSuccessResponseDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/auth/dto/LoginSuccessResponseDto.java
@@ -1,4 +1,4 @@
-package com.sparta.goodbite.auth.dto;
+package com.sparta.goodbite.domain.auth.dto;
 
 public record LoginSuccessResponseDto(String message, String role) {
 

--- a/src/main/java/com/sparta/goodbite/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/goodbite/domain/auth/service/AuthService.java
@@ -1,6 +1,6 @@
-package com.sparta.goodbite.auth.service;
+package com.sparta.goodbite.domain.auth.service;
 
-import com.sparta.goodbite.auth.util.JwtUtil;
+import com.sparta.goodbite.common.util.JwtUtil;
 import com.sparta.goodbite.exception.auth.AuthErrorCode;
 import com.sparta.goodbite.exception.auth.detail.InvalidRefreshTokenException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/sparta/goodbite/domain/customer/controller/CustomerController.java
+++ b/src/main/java/com/sparta/goodbite/domain/customer/controller/CustomerController.java
@@ -1,9 +1,9 @@
 package com.sparta.goodbite.domain.customer.controller;
 
-import com.sparta.goodbite.auth.security.EmailUserDetails;
+import com.sparta.goodbite.security.EmailUserDetails;
 import com.sparta.goodbite.common.response.DataResponseDto;
 import com.sparta.goodbite.common.response.MessageResponseDto;
-import com.sparta.goodbite.common.response.ResponseUtil;
+import com.sparta.goodbite.common.util.ResponseUtil;
 import com.sparta.goodbite.domain.customer.dto.CustomerResponseDto;
 import com.sparta.goodbite.domain.customer.dto.CustomerSignupRequestDto;
 import com.sparta.goodbite.domain.customer.dto.UpdateNicknameRequestDto;

--- a/src/main/java/com/sparta/goodbite/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/goodbite/domain/menu/controller/MenuController.java
@@ -1,9 +1,9 @@
 package com.sparta.goodbite.domain.menu.controller;
 
-import com.sparta.goodbite.auth.security.EmailUserDetails;
+import com.sparta.goodbite.security.EmailUserDetails;
 import com.sparta.goodbite.common.response.DataResponseDto;
 import com.sparta.goodbite.common.response.MessageResponseDto;
-import com.sparta.goodbite.common.response.ResponseUtil;
+import com.sparta.goodbite.common.util.ResponseUtil;
 import com.sparta.goodbite.domain.menu.dto.CreateMenuRequestDto;
 import com.sparta.goodbite.domain.menu.dto.MenuResponseDto;
 import com.sparta.goodbite.domain.menu.dto.UpdateMenuRequestDto;

--- a/src/main/java/com/sparta/goodbite/domain/menu/dto/UpdateMenuRequestDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/menu/dto/UpdateMenuRequestDto.java
@@ -1,6 +1,6 @@
 package com.sparta.goodbite.domain.menu.dto;
 
-import com.sparta.goodbite.domain.menu.dto.validation.constraint.AtLeastOneFieldConstraint;
+import com.sparta.goodbite.common.validation.constraint.AtLeastOneFieldConstraint;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
 

--- a/src/main/java/com/sparta/goodbite/domain/operatinghour/controller/OperatingHourController.java
+++ b/src/main/java/com/sparta/goodbite/domain/operatinghour/controller/OperatingHourController.java
@@ -1,9 +1,9 @@
 package com.sparta.goodbite.domain.operatinghour.controller;
 
-import com.sparta.goodbite.auth.security.EmailUserDetails;
+import com.sparta.goodbite.security.EmailUserDetails;
 import com.sparta.goodbite.common.response.DataResponseDto;
 import com.sparta.goodbite.common.response.MessageResponseDto;
-import com.sparta.goodbite.common.response.ResponseUtil;
+import com.sparta.goodbite.common.util.ResponseUtil;
 import com.sparta.goodbite.domain.operatinghour.dto.CreateOperatingHourRequestDto;
 import com.sparta.goodbite.domain.operatinghour.dto.OperatingHourResponseDto;
 import com.sparta.goodbite.domain.operatinghour.dto.UpdateOperatingHourRequestDto;

--- a/src/main/java/com/sparta/goodbite/domain/operatinghour/dto/CreateOperatingHourRequestDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/operatinghour/dto/CreateOperatingHourRequestDto.java
@@ -1,8 +1,8 @@
 package com.sparta.goodbite.domain.operatinghour.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.sparta.goodbite.domain.operatinghour.dto.validation.contraint.LocalTimeFormatConstraint;
-import com.sparta.goodbite.domain.operatinghour.dto.validation.contraint.OpenTimeBeforeCloseTimeConstraint;
+import com.sparta.goodbite.common.validation.constraint.LocalTimeFormatConstraint;
+import com.sparta.goodbite.common.validation.constraint.OpenTimeBeforeCloseTimeConstraint;
 import com.sparta.goodbite.domain.operatinghour.entity.OperatingHour;
 import com.sparta.goodbite.domain.operatinghour.enums.DayOfWeek;
 import com.sparta.goodbite.domain.restaurant.entity.Restaurant;

--- a/src/main/java/com/sparta/goodbite/domain/operatinghour/dto/UpdateOperatingHourRequestDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/operatinghour/dto/UpdateOperatingHourRequestDto.java
@@ -1,8 +1,8 @@
 package com.sparta.goodbite.domain.operatinghour.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.sparta.goodbite.domain.operatinghour.dto.validation.contraint.LocalTimeFormatConstraint;
-import com.sparta.goodbite.domain.operatinghour.dto.validation.contraint.OpenTimeBeforeCloseTimeConstraint;
+import com.sparta.goodbite.common.validation.constraint.LocalTimeFormatConstraint;
+import com.sparta.goodbite.common.validation.constraint.OpenTimeBeforeCloseTimeConstraint;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalTime;
 import lombok.Getter;

--- a/src/main/java/com/sparta/goodbite/domain/owner/controller/OwnerController.java
+++ b/src/main/java/com/sparta/goodbite/domain/owner/controller/OwnerController.java
@@ -1,9 +1,9 @@
 package com.sparta.goodbite.domain.owner.controller;
 
-import com.sparta.goodbite.auth.security.EmailUserDetails;
+import com.sparta.goodbite.security.EmailUserDetails;
 import com.sparta.goodbite.common.response.DataResponseDto;
 import com.sparta.goodbite.common.response.MessageResponseDto;
-import com.sparta.goodbite.common.response.ResponseUtil;
+import com.sparta.goodbite.common.util.ResponseUtil;
 import com.sparta.goodbite.domain.owner.dto.OwnerResponseDto;
 import com.sparta.goodbite.domain.owner.dto.OwnerSignUpRequestDto;
 import com.sparta.goodbite.domain.owner.dto.UpdateBusinessNumberRequestDto;

--- a/src/main/java/com/sparta/goodbite/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/sparta/goodbite/domain/restaurant/controller/RestaurantController.java
@@ -1,9 +1,9 @@
 package com.sparta.goodbite.domain.restaurant.controller;
 
-import com.sparta.goodbite.auth.security.EmailUserDetails;
+import com.sparta.goodbite.security.EmailUserDetails;
 import com.sparta.goodbite.common.response.DataResponseDto;
 import com.sparta.goodbite.common.response.MessageResponseDto;
-import com.sparta.goodbite.common.response.ResponseUtil;
+import com.sparta.goodbite.common.util.ResponseUtil;
 import com.sparta.goodbite.domain.menu.dto.MenuResponseDto;
 import com.sparta.goodbite.domain.menu.service.MenuService;
 import com.sparta.goodbite.domain.operatinghour.dto.OperatingHourResponseDto;

--- a/src/main/java/com/sparta/goodbite/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/controller/ReviewController.java
@@ -1,9 +1,9 @@
 package com.sparta.goodbite.domain.review.controller;
 
-import com.sparta.goodbite.auth.security.EmailUserDetails;
+import com.sparta.goodbite.security.EmailUserDetails;
 import com.sparta.goodbite.common.response.DataResponseDto;
 import com.sparta.goodbite.common.response.MessageResponseDto;
-import com.sparta.goodbite.common.response.ResponseUtil;
+import com.sparta.goodbite.common.util.ResponseUtil;
 import com.sparta.goodbite.domain.review.dto.CreateReviewRequestDto;
 import com.sparta.goodbite.domain.review.dto.ReviewResponseDto;
 import com.sparta.goodbite.domain.review.dto.UpdateReviewRequestDto;

--- a/src/main/java/com/sparta/goodbite/domain/review/dto/CreateReviewRequestDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/dto/CreateReviewRequestDto.java
@@ -1,8 +1,8 @@
 package com.sparta.goodbite.domain.review.dto;
 
+import com.sparta.goodbite.common.validation.constraint.RatingConstraint;
 import com.sparta.goodbite.domain.customer.entity.Customer;
 import com.sparta.goodbite.domain.restaurant.entity.Restaurant;
-import com.sparta.goodbite.domain.review.dto.validation.constraint.RatingConstraint;
 import com.sparta.goodbite.domain.review.entity.Review;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;

--- a/src/main/java/com/sparta/goodbite/domain/review/dto/UpdateReviewRequestDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/review/dto/UpdateReviewRequestDto.java
@@ -1,6 +1,6 @@
 package com.sparta.goodbite.domain.review.dto;
 
-import com.sparta.goodbite.domain.review.dto.validation.constraint.RatingConstraint;
+import com.sparta.goodbite.common.validation.constraint.RatingConstraint;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/sparta/goodbite/domain/waiting/controller/WaitingController.java
+++ b/src/main/java/com/sparta/goodbite/domain/waiting/controller/WaitingController.java
@@ -1,9 +1,9 @@
 package com.sparta.goodbite.domain.waiting.controller;
 
-import com.sparta.goodbite.auth.security.EmailUserDetails;
+import com.sparta.goodbite.security.EmailUserDetails;
 import com.sparta.goodbite.common.response.DataResponseDto;
 import com.sparta.goodbite.common.response.MessageResponseDto;
-import com.sparta.goodbite.common.response.ResponseUtil;
+import com.sparta.goodbite.common.util.ResponseUtil;
 import com.sparta.goodbite.domain.waiting.dto.PostWaitingRequestDto;
 import com.sparta.goodbite.domain.waiting.dto.UpdateWaitingRequestDto;
 import com.sparta.goodbite.domain.waiting.dto.WaitingResponseDto;

--- a/src/main/java/com/sparta/goodbite/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/goodbite/exception/GlobalExceptionHandler.java
@@ -1,7 +1,7 @@
 package com.sparta.goodbite.exception;
 
 import com.sparta.goodbite.common.response.MessageResponseDto;
-import com.sparta.goodbite.common.response.ResponseUtil;
+import com.sparta.goodbite.common.util.ResponseUtil;
 import com.sparta.goodbite.exception.customer.CustomerException;
 import com.sparta.goodbite.exception.auth.AuthException;
 import com.sparta.goodbite.exception.menu.MenuException;
@@ -67,7 +67,7 @@ public class GlobalExceptionHandler {
         log.error("에러 발생: ", e);
         return ResponseUtil.of(e.getOperatingHourErrorCode().getHttpStatus(), e.getMessage());
     }
-  
+
     @ExceptionHandler(WaitingException.class)
     public ResponseEntity<MessageResponseDto> handleWaitingException(WaitingException e) {
         log.error("에러 발생: ", e);

--- a/src/main/java/com/sparta/goodbite/security/EmailLogoutSuccessHandler.java
+++ b/src/main/java/com/sparta/goodbite/security/EmailLogoutSuccessHandler.java
@@ -1,7 +1,7 @@
-package com.sparta.goodbite.auth.security;
+package com.sparta.goodbite.security;
 
-import com.sparta.goodbite.auth.util.JwtUtil;
-import com.sparta.goodbite.common.response.ResponseUtil;
+import com.sparta.goodbite.common.util.JwtUtil;
+import com.sparta.goodbite.common.util.ResponseUtil;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/sparta/goodbite/security/EmailUserDetails.java
+++ b/src/main/java/com/sparta/goodbite/security/EmailUserDetails.java
@@ -1,4 +1,4 @@
-package com.sparta.goodbite.auth.security;
+package com.sparta.goodbite.security;
 
 import com.sparta.goodbite.common.UserCredentials;
 import java.util.ArrayList;

--- a/src/main/java/com/sparta/goodbite/security/EmailUserDetailsService.java
+++ b/src/main/java/com/sparta/goodbite/security/EmailUserDetailsService.java
@@ -1,6 +1,6 @@
-package com.sparta.goodbite.auth.security;
+package com.sparta.goodbite.security;
 
-import com.sparta.goodbite.auth.UserRole;
+import com.sparta.goodbite.domain.auth.UserRole;
 import com.sparta.goodbite.domain.customer.entity.Customer;
 import com.sparta.goodbite.domain.customer.repository.CustomerRepository;
 import com.sparta.goodbite.domain.owner.entity.Owner;

--- a/src/main/java/com/sparta/goodbite/security/GlobalAccessDeniedHandler.java
+++ b/src/main/java/com/sparta/goodbite/security/GlobalAccessDeniedHandler.java
@@ -1,6 +1,6 @@
-package com.sparta.goodbite.auth.security;
+package com.sparta.goodbite.security;
 
-import com.sparta.goodbite.common.response.ResponseUtil;
+import com.sparta.goodbite.common.util.ResponseUtil;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/sparta/goodbite/security/GlobalAuthenticationEntryPoint.java
+++ b/src/main/java/com/sparta/goodbite/security/GlobalAuthenticationEntryPoint.java
@@ -1,6 +1,6 @@
-package com.sparta.goodbite.auth.security;
+package com.sparta.goodbite.security;
 
-import com.sparta.goodbite.common.response.ResponseUtil;
+import com.sparta.goodbite.common.util.ResponseUtil;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/sparta/goodbite/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/goodbite/security/JwtAuthenticationFilter.java
@@ -1,10 +1,10 @@
-package com.sparta.goodbite.auth.security;
+package com.sparta.goodbite.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sparta.goodbite.auth.dto.LoginRequestDto;
-import com.sparta.goodbite.auth.dto.LoginSuccessResponseDto;
-import com.sparta.goodbite.auth.util.JwtUtil;
-import com.sparta.goodbite.common.response.ResponseUtil;
+import com.sparta.goodbite.domain.auth.dto.LoginRequestDto;
+import com.sparta.goodbite.domain.auth.dto.LoginSuccessResponseDto;
+import com.sparta.goodbite.common.util.JwtUtil;
+import com.sparta.goodbite.common.util.ResponseUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/sparta/goodbite/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/goodbite/security/JwtAuthorizationFilter.java
@@ -1,7 +1,7 @@
-package com.sparta.goodbite.auth.security;
+package com.sparta.goodbite.security;
 
-import com.sparta.goodbite.auth.util.JwtUtil;
-import com.sparta.goodbite.common.response.ResponseUtil;
+import com.sparta.goodbite.common.util.JwtUtil;
+import com.sparta.goodbite.common.util.ResponseUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;


### PR DESCRIPTION
제목 : [✨FEAT] / 패키지 구조 리팩토링
feat(issue 번호): #165

## 🔎 작업 내용

- Auth 패키지 도메인 하위 패키지로 이동
- Auth 패키지 내부에서 도메인 성격을 띄지 않는 패키지 외부로 이동
- 커스텀 유효성 검사 패키지 common 하위로 이동
- 설정 관련된 파일 config 패키지로 이동
- common 패키지 내에 util 패키지 추가 및 `ResponseUtil`, `JwtUtil` 포함
<img width="707" alt="image" src="https://github.com/user-attachments/assets/a2a5ce9a-1952-4c0e-8b25-ea873713d3a9">

<img width="719" alt="image" src="https://github.com/user-attachments/assets/f0b69977-c12e-4f36-87e4-ff841769e9fb">


## 🔗 이슈 링크

- [x] #166
- [x] #167 
- [x] #168 
- [x] #169 

resolved: #165
