### PR TITLE
207 bug 브랜치 병합 중 restaurant 도메인 에러 발생 수정

### DIFF
--- a/src/main/java/com/sparta/goodbite/domain/restaurant/dto/RestaurantResponseDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/restaurant/dto/RestaurantResponseDto.java
@@ -4,7 +4,7 @@ import com.sparta.goodbite.domain.restaurant.entity.Restaurant;
 import com.sparta.goodbite.domain.restaurant.enums.Category;
 
 public record RestaurantResponseDto(Long restaurantId, String name, String imageUrl, String address,
-                                    String area, String phoneNumber, String category,
+                                    String area, String phoneNumber, Category category,
                                     int capacity) {
 
     public static RestaurantResponseDto from(Restaurant restaurant) {

--- a/src/main/java/com/sparta/goodbite/domain/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/sparta/goodbite/domain/restaurant/entity/Restaurant.java
@@ -45,7 +45,7 @@ public class Restaurant extends Timestamped {
 
     @Builder
     public Restaurant(Owner owner, String name, String imageUrl, String address, String area,
-        String phoneNumber, Category category) {
+        String phoneNumber, Category category, int capacity) {
         this.owner = owner;
         this.name = name;
         this.imageUrl = imageUrl;


### PR DESCRIPTION
제목 : [🩹FIX] 브랜치 병합 중 restaurant 도메인 에러 발생 수정
feat(issue 번호): #207

## 🔎 작업 내용

- Restaurant 생성자에 `capacity` 매개변수 추가
- `RestaurantResponseDto`의 `category` 타입 수정

## 🔗 이슈 링크


resolved: #207
