### PR TITLE
♻️ refactor: 주소 관련 필드 수정

### DIFF
--- a/src/main/java/com/sparta/goodbite/domain/restaurant/dto/RestaurantRequestDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/restaurant/dto/RestaurantRequestDto.java
@@ -11,19 +11,22 @@ import lombok.Getter;
 @Getter
 public class RestaurantRequestDto {
 
-    @NotBlank(message = "가게 이름을 입력해주세요.")
+    @NotBlank(message = "식당 이름을 입력해주세요.")
     private String name;
 
-//    @NotBlank(message = "가게 사진을 넣어주세요.")
-//    private String imageUrl;
+    @NotBlank(message = "식당의 시/도를 입력해 주세요.")
+    private String sido;
 
-    @NotBlank(message = "가게 주소를 입력해주세요.")
+    @NotBlank(message = "식당의 시/군/구를 입력해 주세요.")
+    private String sigungu;
+
+    @NotBlank(message = "식당 주소를 입력해주세요.")
     private String address;
 
-    @NotBlank(message = "가게 지역을 입력해주세요.")
-    private String area;
+    @NotBlank(message = "식당 상세 주소를 입력해주세요.")
+    private String detailAddress;
 
-    @NotBlank(message = "가게 전화번호를 입력해주세요.")
+    @NotBlank(message = "식당 전화번호를 입력해주세요.")
     @Pattern(regexp = "^(0[2-8][0-5]?|01[01346-9])-?([1-9]{1}[0-9]{2,3})-?([0-9]{4})$", message = "전화번호 형식에 맞게 입력해주세요.")
     private String phoneNumber;
 
@@ -38,8 +41,10 @@ public class RestaurantRequestDto {
             .owner(owner)
             .name(name)
             .imageUrl(image)
+            .sido(sido)
+            .sigungu(sigungu)
             .address(address)
-            .area(area)
+            .detailAddress(detailAddress)
             .phoneNumber(phoneNumber)
             .category(category)
             .capacity(capacity)

--- a/src/main/java/com/sparta/goodbite/domain/restaurant/dto/RestaurantResponseDto.java
+++ b/src/main/java/com/sparta/goodbite/domain/restaurant/dto/RestaurantResponseDto.java
@@ -3,17 +3,19 @@ package com.sparta.goodbite.domain.restaurant.dto;
 import com.sparta.goodbite.domain.restaurant.entity.Restaurant;
 import com.sparta.goodbite.domain.restaurant.enums.Category;
 
-public record RestaurantResponseDto(Long restaurantId, String name, String imageUrl, String address,
-                                    String area, String phoneNumber, Category category,
-                                    int capacity) {
+public record RestaurantResponseDto(Long restaurantId, String name, String imageUrl, String sido,
+                                    String sigungu, String address, String detailAddress,
+                                    String phoneNumber, Category category, int capacity) {
 
     public static RestaurantResponseDto from(Restaurant restaurant) {
         return new RestaurantResponseDto(
             restaurant.getId(),
             restaurant.getName(),
             restaurant.getImageUrl(),
+            restaurant.getSido(),
+            restaurant.getSigungu(),
             restaurant.getAddress(),
-            restaurant.getArea(),
+            restaurant.getDetailAddress(),
             restaurant.getPhoneNumber(),
             restaurant.getCategory(),
             restaurant.getCapacity());

--- a/src/main/java/com/sparta/goodbite/domain/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/sparta/goodbite/domain/restaurant/entity/Restaurant.java
@@ -35,8 +35,10 @@ public class Restaurant extends Timestamped {
     @Column(length = 2083)
     private String imageUrl;
 
+    private String sido;
+    private String sigungu;
     private String address;
-    private String area;
+    private String detailAddress;
     private String phoneNumber;
     private int capacity;
 
@@ -44,13 +46,15 @@ public class Restaurant extends Timestamped {
     private Category category;
 
     @Builder
-    public Restaurant(Owner owner, String name, String imageUrl, String address, String area,
-        String phoneNumber, Category category, int capacity) {
+    public Restaurant(Owner owner, String name, String imageUrl, String sido, String sigungu,
+        String address, String detailAddress, String phoneNumber, Category category, int capacity) {
         this.owner = owner;
         this.name = name;
         this.imageUrl = imageUrl;
+        this.sido = sido;
+        this.sigungu = sigungu;
         this.address = address;
-        this.area = area;
+        this.detailAddress = detailAddress;
         this.phoneNumber = phoneNumber;
         this.category = category;
         this.capacity = capacity;
@@ -59,8 +63,10 @@ public class Restaurant extends Timestamped {
     public void update(RestaurantRequestDto restaurantRequestDto, String restaurantImage) {
         this.name = restaurantRequestDto.getName();
         this.imageUrl = restaurantImage;
+        this.sido = restaurantRequestDto.getSido();
+        this.sigungu = restaurantRequestDto.getSigungu();
         this.address = restaurantRequestDto.getAddress();
-        this.area = restaurantRequestDto.getArea();
+        this.detailAddress = restaurantRequestDto.getDetailAddress();
         this.phoneNumber = restaurantRequestDto.getPhoneNumber();
         this.category = restaurantRequestDto.getCategory();
         this.capacity = restaurantRequestDto.getCapacity();


### PR DESCRIPTION
제목 : [♻️REFACTOR] 식당 주소 관련 필드 수정
feat(issue 번호): #248 

## 🔎 작업 내용

- 메시지의 `"가게"`를 `"식당"`으로 대체
  - 가게는 Restaurant보다는 Store의 느낌이 강함
- `Restaurant` 엔티티 및 요청/응답 DTO의 주소 관련 필드 수정
  - `area` 삭제
  - `sido`, `sigungu`, `detailAddress` 추가
- 프론트에서 전체 주소는 `address` + `detailAddress`로 반영
- `sido`(시/도), `sigungu`(시/군/구)는 검색 필터링에 필요하기 때문에 추가

## 🔗 이슈 링크

- [x] #249
- [x] #250

resolved: #248
